### PR TITLE
Fix: kafka 범위 제한

### DIFF
--- a/src/main/java/com/multitap/chat/chat/application/ChatServiceImpl.java
+++ b/src/main/java/com/multitap/chat/chat/application/ChatServiceImpl.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.multitap.chat.chat.domain.MessageType.NOTICE;
+import static com.multitap.chat.chat.domain.MessageType.TEXT;
 import static com.multitap.chat.common.response.BaseResponseStatus.*;
 
 @Slf4j
@@ -73,7 +74,9 @@ public class ChatServiceImpl implements ChatService {
                     log.info("Create chat chatMessageDto: {}", chatMessageDto.toString());
 
                     // Kafka에 메시지 전송
-                    kafkaProducerService.sendCreateChatMessageList(chatMessageDto);
+                    if (createChatRequestDto.getMessageType() == TEXT) {
+                        kafkaProducerService.sendCreateChatMessageList(chatMessageDto);
+                    }
 
                     // void 반환
                     return Mono.empty();


### PR DESCRIPTION
#60
kafka로 보낼 메시지의 범위를 TEXT로 제한했습니다.
 -> 가장 최근의 메시지가 퇴장 NOTICE가 되지 않게 하기 위해서